### PR TITLE
Fix docs build badge on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 Python Course
 =============
 
-.. image::  https://readthedocs.org/projects/curso-python/badge/?version=latest
-   :alt: Read the Docs
+.. image:: https://readthedocs.org/projects/curso-python/badge/?version=latest
+    :target: https://readthedocs.org/projects/curso-python/builds/
+    :alt: Documentation Status
 
 This repo contains the material for the Introductory Python course created by grupy-sanca.
 


### PR DESCRIPTION
read the docs build badge link is broken. update it to redirect to the builds page.