### PR TITLE
Added summary for dicts and lists 

### DIFF
--- a/source/contribuidores.rst
+++ b/source/contribuidores.rst
@@ -14,6 +14,7 @@ Lista de pessoas que contribuíram com a criação deste material:
 - Luiz Fernando S. E. Santos
 - Marcel T. Nakamine
 - Marcelo Miky Mine (Telegram: @marcelomiky / email: marcelo.mine@gmail.com)
+- Thiago Ferreira
 - Tiago Martins
 - Víctor Cora Colombo
 - Yara Torres de Souza

--- a/source/dicionarios.rst
+++ b/source/dicionarios.rst
@@ -396,3 +396,30 @@ Exercícios
 ----------
 
 .. include:: exercicios_dicionario.rst
+
+
+Sumário
+--------
+
+.. csv-table::
+  :header: "Operação", "Descrição"
+  :widths: auto
+  :delim: ;
+
+  ``telefones = {"Ana": 123456, "yudi": 654321}``           ; Cria um dicionário com duas chaves, usando ``{}``
+  ``telefones = dict(Ana=123456, yudi=654321)``             ; Cria um dicionário com duas chaves, usando o método ``dict()``
+  ``telefones = dict((("Ana", 123456), ("yudi", 654321)))`` ; Cria um dicionário com duas chaves a partir de uma lista de tuplas
+  ``telefones["Ana"] # Retorna 123456``                     ; Acessa o valor do telefone da chave "Ana"
+  ``telefone["thiago"] = 9876543``                          ; Adiciona mais um telefone na lista
+  ``del telefone["thiago"]``                                ; Remove um telefone do dicionário
+  ``telefone.clear()``                                      ; Remove todos os elementos de um dicionário
+  ``dict1.update(dict2)``                                   ; Para versões anteriores a 3.9 do Python, use o método ``.update()`` para colocar o conteúdo de um segundo dicionário no original
+  ``dict1 | dict2``                                         ; A partir da versão 3.9 do Python, é possível unificar dois dicionários com o operador ``|`` (barra vertical ou pipe – em inglês)
+  ``list(telefones) # Retorna ["Ana", "yudi"]``             ; Obtém as chaves de um dicionário
+  ``telefones.keys() # Retorna ("Ana", "yudi")``            ; Obtém as chaves de um dicionário
+  ``len(telefones)``                                        ; Retorna a quantidade de chaves no dicionário
+  ``telefones.get("João", "N/A")``                          ; Retorna o valor associado à chave ``João`` ou ``N/A`` caso a chave não exista.
+  ``telefones.items()``                                     ; Retorna uma lista de tuplas contendo a chave e o valor de cada item do dicionário
+  ``telefones.values()``                                    ; Retorna uma lista com apenas os valores dos dicionários
+  ``"Ana" in telefones``                                    ; Verifica se a chave "Ana" existe no dicionário
+  ``telefones.popitem()``                                   ; Remove e retorna a última chave do dicionário

--- a/source/listas.rst
+++ b/source/listas.rst
@@ -290,3 +290,28 @@ Exercícios
 
 .. o range faz parte de listas neste contexto
 .. include:: range.rst
+
+
+Sumário
+--------
+
+.. csv-table::
+  :header: "Operação", "Descrição"
+  :widths: auto
+  :delim: ;
+
+  ``lista = ['maçã', 'banana', 'abacaxi']``   ; Cria uma nova lista com 3 itens
+  ``lista = []``                              ; Cria uma lista vazia
+  ``lista = list()``                          ; Outra opção para criar uma lista vazia
+  ``lista.append(item)``                      ; Adiciona um item no fim da lista
+  ``lista.insert(2, 'caju')``                 ; insere um elemento na posição especificada e move os demais elementos para direita
+  ``lista[0]``                                ; Acessa o primeiro item da lista (os índices começam em 0)
+  ``lista[-1]``                               ; Acessa o último item da lista
+  ``lista[-2]``                               ; Acessa o penúltimo item da lista
+  ``lista[2:4]``                              ; Retorna uma fatia da posição 2 até a 4 (não inclusa)
+  ``'maça' in lista``                         ; Verifica se o item ``maça`` existe na lista
+  ``del lista[0]``                            ; Remove o primeiro item da lista
+  ``lista1 + lista2``                         ; Concatena duas listas em um uma nova
+  ``lista1.extend(lista2)``                   ; Atualiza a lista1, adicionando todos os elementos da lista2
+  ``[0] * 3 => [0, 0, 0]``                    ; O operador ``*`` repete a lista dado um número de vezes
+  ``list(range(10))``                         ; Produz uma lista com um intervalo de números: ``[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]``


### PR DESCRIPTION
## Testing instructions
- Install the project in your local machine using [these instructions](https://github.com/grupy-sanca/curso-python#how-to-use-locally)
- Then, run `make html` to generate the html files
- Now open the files on your browser using:
```
# on macoS:
open build/html/index.html
# On linux:
xdg-open build/html/index.html
```

Now check the pages `listas` and `dictionaries`.

## Screenshots

### Lists
![image](https://user-images.githubusercontent.com/9268203/138570436-275f2e66-eb15-429a-937e-c37edc345fcf.png)

### Dicts
![image](https://user-images.githubusercontent.com/9268203/138570448-3dcb5175-851a-43cc-a700-b0f55132d684.png)


## Possible problems

I still couldn't make the first column width to be larger 😩 Any ideas on how to solve this? 
It seems like the CSS for code tags is somehow not considering the full width.

## Issues 
- Solves partially: https://github.com/grupy-sanca/curso-python/pull/108