### PR TITLE
Fixed sphinx-rtd-theme==0.5.2 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-sphinx
-sphinx_rtd_theme
+sphinx>=4.2.0
 sphinxcontrib-spelling>=4.2.1
+# Fixed version on sphinx-rtd-theme, since >=1.0.0 is fairly new and have some issues.
+# See: https://github.com/grupy-sanca/curso-python/pull/108#issuecomment-950395761 for details
+sphinx-rtd-theme==0.5.2


### PR DESCRIPTION
## Contexto
Conforme a discussão no PR (https://github.com/grupy-sanca/curso-python/pull/108#issuecomment-950395761), precisamos fixar a dependencia do `sphinx-rtd-theme`, pois na versão mais nova `1.0.0` estamos tendo problemas com o layout de tabelas que usam a tag de código.

## Solução proposta

~~Usei o pip-tools para criar um arquivo requirements.in pra salvar nossas preferências de versão. Assim podemos usar o `pip-compile` para resolver as dependencias e ter um arquivo de versões travadas.~~

~~Isso ajudará no futuro a evitar que novas versões quebrem o projeto 😩~~

UPDATE: Fiz uma atualização para usar apenas o `requirements.txt`

## Outras opções

~~Também podemos usar o [poetry](https://python-poetry.org/) pra isso, me avisem se preferirem que eu troque 🙌~~

~~Nesse momento escolhi usar o `pip-tools` pra não mudar demais a estrutura do projeto e usar as ferramentas nativas do python. Mas como disse, se preferirem o poetry, só avisar que ajusto aqui 🙌~~