### PR TITLE
Add Linkedin no cap Sobre Grupy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
+.idea/
 build/
 develop-eggs/
 dist/

--- a/source/contribuidores.rst
+++ b/source/contribuidores.rst
@@ -9,6 +9,7 @@ Lista de pessoas que contribuíram com a criação deste material:
 - Guilherme Martins
 - Heitor de Bittencourt
 - Juliana Karoline
+- Leonardo C. Oliveira
 - Lucas Carvalho
 - Luiz Menezes
 - Luiz Fernando S. E. Santos

--- a/source/sobre_grupy.rst
+++ b/source/sobre_grupy.rst
@@ -219,30 +219,12 @@ Para saber mais sobre os eventos organizados pelo grupy-sanca acesse:
     .. only:: latex
 
        www.grupysanca.com.br
-
-  - `Facebook <https://www.facebook.com/grupysanca/>`_
-
-    .. only:: latex
-
-       facebook.com/grupysanca
-
-  - `Instagram <https://www.instagram.com/grupysanca/>`_
+   
+  - `GitHub <https://github.com/grupy-sanca>`_
 
     .. only:: latex
 
-       instagram.com/grupysanca/
-
-  - `Telegram <https://t.me/grupysanca>`_
-
-    .. only:: latex
-
-       t.me/grupysanca
-
-  - `Discord <https://discord.gg/AgS2dBa>`_
-
-    .. only:: latex
-
-       discord.gg/AgS2dBa
+       github.com/grupy-sanca
 
   - `Meetup <https://www.meetup.com/grupy-sanca>`_
 
@@ -250,17 +232,35 @@ Para saber mais sobre os eventos organizados pelo grupy-sanca acesse:
 
        meetup.com/grupy-sanca
 
+  - `Discord <https://discord.gg/AgS2dBa>`_
+
+    .. only:: latex
+
+       discord.gg/AgS2dBa
+
   - `YouTube <https://www.youtube.com/grupysanca>`_
 
     .. only:: latex
 
        youtube.com/grupysanca
 
-  - `GitHub <https://github.com/grupy-sanca>`_
+  - `Instagram <https://www.instagram.com/grupysanca/>`_
 
     .. only:: latex
 
-       github.com/grupy-sanca
+       instagram.com/grupysanca/
+
+  - `Linkedin <https://www.linkedin.com/company/grupy-sanca>`_
+
+    .. only:: latex
+
+       instagram.com/grupysanca/
+
+  - `Facebook <https://www.facebook.com/grupysanca/>`_
+
+    .. only:: latex
+
+       facebook.com/grupysanca
 
 .. spelling::
 


### PR DESCRIPTION
Adicionei os diretórios:
.venv/
.idea/
no .gitignore

Alterei os links no cap Sobre Grupy (mudei a ordem e tirei o link para o grupo do telegram que não estava funcionando).
Antes:
[Site oficial](http://www.grupysanca.com.br/)
[Facebook](https://www.facebook.com/grupysanca/)
[Instagram](https://www.instagram.com/grupysanca/)
[Telegram](https://t.me/grupysanca)
[Discord](https://discord.gg/AgS2dBa)
[Meetup](https://www.meetup.com/grupy-sanca)
[YouTube](https://www.youtube.com/grupysanca)
[GitHub](https://github.com/grupy-sanca)

Alteração:
[Site oficial](http://www.grupysanca.com.br/)
[GitHub](https://github.com/grupy-sanca)
[Meetup](https://www.meetup.com/grupy-sanca)
[Discord](https://discord.gg/AgS2dBa)
[YouTube](https://www.youtube.com/grupysanca)
[Instagram](https://www.instagram.com/grupysanca/)
[Linkedin](https://www.linkedin.com/company/grupy-sanca)
[Facebook](https://www.facebook.com/grupysanca/)

O único critério que pensei para ordenar foi colocar as redes mais usadas/ativas primeiro.