### PR TITLE
Atualiza o README com instruções para macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ How to use locally
 
       # On macOS
       $ brew update && brew install enchant
+      $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
       # On Debian based distros (linux Mint, Ubuntu...)
       $ sudo apt update && sudo apt install enchant-2 python3-enchant hunspell hunspell-pt-br
 


### PR DESCRIPTION
Atualiza o `README` do projeto com instruções específicas para o `macOS`.
Após instalar o `enchant` com o `brew`, é preciso setar uma env var com o caminho da biblioteca em C para que seja possível buildar o projeto.
Esse passo parece ser necessário para computadores M1 e M2.