### PR TITLE
Fix theme on RTD

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-import os
 import datetime
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
@@ -84,13 +83,10 @@ spelling_word_list_filename = '../new_words_spell_checker.txt'
 
 # -- Options for HTML output ----------------------------------------------
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-if not on_rtd:
-    html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Always set `html_theme` to `sphinx_rtd_theme`, regardless of the environment.